### PR TITLE
remove misplaced newlines after $python

### DIFF
--- a/rose-pine-dawn.toml
+++ b/rose-pine-dawn.toml
@@ -15,7 +15,7 @@ $nodejs \
 $nim \
 $rust \
 $scala \
-$python\n  \
+$python \
 $time\n  \
 [󱞪](fg:iris)
 """

--- a/rose-pine-moon.toml
+++ b/rose-pine-moon.toml
@@ -15,7 +15,7 @@ $nodejs \
 $nim \
 $rust \
 $scala \
-$python\n  \
+$python \
 $time\n  \
 [󱞪](fg:iris)
 """

--- a/rose-pine.toml
+++ b/rose-pine.toml
@@ -15,7 +15,7 @@ $nodejs \
 $nim \
 $rust \
 $scala \
-$python\n  \
+$python \
 $time\n  \
 [󱞪](fg:iris)
 """


### PR DESCRIPTION
The newlines symbols after $python cause time to be printed on a new line unlike the example picture
