### PR TITLE
fix: add space to rust symbol

### DIFF
--- a/rose-pine-dawn.toml
+++ b/rose-pine-dawn.toml
@@ -142,7 +142,7 @@ symbol = "󰆥 "
 style = "bg:overlay fg:pine"
 format = "[](fg:overlay)[$symbol$version]($style)[](fg:overlay) "
 disabled = false
-symbol = ""
+symbol = " "
 
 [scala]
 style = "bg:overlay fg:pine"

--- a/rose-pine-moon.toml
+++ b/rose-pine-moon.toml
@@ -142,7 +142,7 @@ symbol = "󰆥 "
 style = "bg:overlay fg:pine"
 format = "[](fg:overlay)[$symbol$version]($style)[](fg:overlay) "
 disabled = false
-symbol = ""
+symbol = " "
 
 [scala]
 style = "bg:overlay fg:pine"

--- a/rose-pine.toml
+++ b/rose-pine.toml
@@ -142,7 +142,7 @@ symbol = "󰆥 "
 style = "bg:overlay fg:pine"
 format = "[](fg:overlay)[$symbol$version]($style)[](fg:overlay) "
 disabled = false
-symbol = ""
+symbol = " "
 
 [scala]
 style = "bg:overlay fg:pine"


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/1df6305f-3d4c-45d8-b591-cd7aa58e0476)
After
![image](https://github.com/user-attachments/assets/c23f1154-0a99-4024-92e3-e93e98ea09da)
